### PR TITLE
Avoid importing error for compressed media file

### DIFF
--- a/src/WXRImporter.php
+++ b/src/WXRImporter.php
@@ -1821,11 +1821,6 @@ class WXRImporter extends \WP_Importer {
 		$filesize = filesize( $upload['file'] );
 		$headers = wp_remote_retrieve_headers( $response );
 
-		if ( isset( $headers['content-length'] ) && $filesize !== (int) $headers['content-length'] ) {
-			unlink( $upload['file'] );
-			return new \WP_Error( 'import_file_error', __( 'Remote file is incorrect size', 'wordpress-importer' ) );
-		}
-
 		if ( 0 === $filesize ) {
 			unlink( $upload['file'] );
 			return new \WP_Error( 'import_file_error', __( 'Zero size file downloaded', 'wordpress-importer' ) );


### PR DESCRIPTION
Some media file such as PNG may be compressed by server.
Thus the value content-length and actual file size can be different.